### PR TITLE
fix: publish release assets and ClawHub skills from release-please

### DIFF
--- a/.github/workflows/clawhub.yml
+++ b/.github/workflows/clawhub.yml
@@ -1,6 +1,12 @@
 name: Sync OpenClaw Skills
 
 on:
+  workflow_call:
+    inputs:
+      ref:
+        description: Git ref or tag to sync from
+        required: false
+        type: string
   pull_request:
     branches:
       - main
@@ -15,8 +21,6 @@ on:
     branches:
       - main
 
-    tags:
-      - "v*"
     paths:
       - "skills/**"
       - "scripts/package_openclaw_skill.py"
@@ -24,6 +28,11 @@ on:
       - "justfile"
       - "vx.toml"
   workflow_dispatch:
+    inputs:
+      ref:
+        description: Git ref or tag to sync from
+        required: false
+        type: string
 
 permissions:
   contents: read
@@ -45,6 +54,8 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ ((github.event_name == 'workflow_call' || github.event_name == 'workflow_dispatch') && inputs.ref) || github.ref }}
 
       - name: Setup vx
         uses: loonghao/vx@main
@@ -55,31 +66,11 @@ jobs:
       - name: Setup tools (vx)
         run: vx setup
 
-      - name: Verify Cargo version matches tag
-        if: startsWith(github.ref, 'refs/tags/v')
-        shell: bash
-        run: |
-          cargo_version="$(vx uv run python - <<'PY'
-
-          import tomllib
-          from pathlib import Path
-
-          data = tomllib.loads(Path('Cargo.toml').read_text(encoding='utf-8'))
-          print(data['workspace']['package']['version'])
-          PY
-          )"
-
-          expected_tag="v${cargo_version}"
-          if [[ "${GITHUB_REF_NAME}" != "${expected_tag}" ]]; then
-            echo "Tag ${GITHUB_REF_NAME} does not match workspace version ${cargo_version}" >&2
-            exit 1
-          fi
-
       - name: Package all skills
         run: vx just package-skills
 
       - name: Upload packaged skill artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v6
         with:
           name: skill-packages
           path: dist/skills/*.zip

--- a/.github/workflows/generate-skills.yml
+++ b/.github/workflows/generate-skills.yml
@@ -51,8 +51,9 @@ jobs:
         run: vx just package-skills
 
       - name: Upload packaged skill artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v6
         with:
+
           name: skill-packages
           path: dist/skills/*.zip
           if-no-files-found: error

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -21,6 +21,9 @@ jobs:
   release-please:
     name: Release Please
     runs-on: ubuntu-latest
+    outputs:
+      release_created: ${{ steps.release.outputs['crates/fpt-cli--release_created'] }}
+      tag_name: ${{ steps.release.outputs['crates/fpt-cli--tag_name'] }}
     steps:
       - name: Run release-please
         id: release
@@ -29,3 +32,21 @@ jobs:
           token: ${{ secrets.RELEASE_PLEASE_TOKEN != '' && secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+  publish-release:
+    name: Publish CLI release
+    needs: release-please
+    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    uses: ./.github/workflows/release.yml
+    with:
+      tag_name: ${{ needs.release-please.outputs.tag_name }}
+    secrets: inherit
+
+  publish-skills:
+    name: Publish skills to ClawHub
+    needs: release-please
+    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    uses: ./.github/workflows/clawhub.yml
+    with:
+      ref: refs/tags/${{ needs.release-please.outputs.tag_name }}
+    secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,18 @@
 name: Release
 
 on:
-  push:
-    tags:
-      - "v*"
-
+  workflow_call:
+    inputs:
+      tag_name:
+        description: Release tag to build and publish
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: Release tag to build and publish
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -20,6 +28,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: refs/tags/${{ inputs.tag_name }}
 
       - name: Setup vx
         uses: loonghao/vx@main
@@ -32,6 +42,8 @@ jobs:
 
       - name: Verify Cargo version matches tag
         shell: bash
+        env:
+          RELEASE_TAG: ${{ inputs.tag_name }}
         run: |
           cargo_version="$(vx uv run python - <<'PY'
 
@@ -44,8 +56,8 @@ jobs:
           )"
 
           expected_tag="v${cargo_version}"
-          if [[ "${GITHUB_REF_NAME}" != "${expected_tag}" ]]; then
-            echo "Tag ${GITHUB_REF_NAME} does not match workspace version ${cargo_version}" >&2
+          if [[ "${RELEASE_TAG}" != "${expected_tag}" ]]; then
+            echo "Tag ${RELEASE_TAG} does not match workspace version ${cargo_version}" >&2
             exit 1
           fi
 
@@ -75,6 +87,8 @@ jobs:
             binary_name: fpt
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: refs/tags/${{ inputs.tag_name }}
 
       - name: Setup vx
         uses: loonghao/vx@main
@@ -116,21 +130,19 @@ jobs:
           Compress-Archive -Path "target/${{ matrix.target }}/release/${{ matrix.binary_name }}" -DestinationPath "dist/${{ matrix.archive_name }}" -Force
 
       - name: Upload release artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ matrix.target }}
           path: dist/${{ matrix.archive_name }}
           if-no-files-found: error
 
   github-release:
-    name: Create GitHub Release
+    name: Upload GitHub Release assets
     runs-on: ubuntu-latest
     needs: build
     steps:
-      - uses: actions/checkout@v6
-
       - name: Download build artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v6
         with:
           path: artifacts
           pattern: '*'
@@ -142,7 +154,7 @@ jobs:
           cd artifacts
           sha256sum fpt-* > fpt-checksums.txt
 
-      - name: Prepare release notes
+      - name: Prepare fallback release notes
         shell: bash
         run: |
           cat > RELEASE_NOTES.md <<'EOF'
@@ -152,14 +164,12 @@ jobs:
 
           ```bash
           curl -fsSL https://raw.githubusercontent.com/${{ github.repository }}/main/scripts/install.sh | sh
-
           ```
 
           ### Windows PowerShell
 
           ```powershell
           powershell -ExecutionPolicy Bypass -c "irm https://raw.githubusercontent.com/${{ github.repository }}/main/scripts/install.ps1 | iex"
-
           ```
 
           ### In-place update
@@ -175,15 +185,14 @@ jobs:
           ```
           EOF
 
-      - name: Create GitHub Release
-        uses: ncipollo/release-action@v1
-        with:
-          tag: ${{ github.ref_name }}
-          name: ${{ github.ref_name }}
-          bodyFile: RELEASE_NOTES.md
-          artifacts: artifacts/*
-          allowUpdates: true
-          artifactErrorsFailBuild: true
-          draft: false
-          prerelease: ${{ contains(github.ref_name, '-') }}
-          makeLatest: true
+      - name: Upload release assets
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ inputs.tag_name }}
+        run: |
+          if gh release view "${RELEASE_TAG}" > /dev/null 2>&1; then
+            gh release upload "${RELEASE_TAG}" artifacts/* --clobber
+          else
+            gh release create "${RELEASE_TAG}" artifacts/* --title "${RELEASE_TAG}" --notes-file RELEASE_NOTES.md
+          fi

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Use the single-skill packaging alias when you only want the OpenClaw bundle:
 vx just package-openclaw-skill
 ```
 
-`generate-skills.yml` packages all skill directories under `skills/`, while `clawhub.yml` runs a ClawHub dry-run sync on pull requests and syncs the same root on `main` / tag pushes.
+`generate-skills.yml` packages all skill directories under `skills/`, while `clawhub.yml` runs a ClawHub dry-run sync on pull requests and syncs the same root on `main` pushes.
 
 
 
@@ -115,13 +115,14 @@ Version management is handled by **`release-please`**:
 - Push conventional commits to `main`
 - `release-please` opens or updates a release PR
 - Merging the release PR creates the version tag and GitHub release metadata
-- The tag-triggered `release.yml` workflow publishes the cross-platform CLI archives
+- `release-please.yml` then directly calls the reusable `release.yml` workflow to publish the cross-platform CLI archives for the created tag
 - `generate-skills.yml` packages every skill under `skills/`
-- The push/tag-triggered `clawhub.yml` workflow syncs the `skills/` root to ClawHub, while pull requests run a dry-run sync
+- `clawhub.yml` runs a dry-run sync on pull requests, syncs the `skills/` root on `main` pushes, and is also called directly by `release-please.yml` so release-time ClawHub publishing does not depend on a second tag-triggered workflow run
 
-For fully automatic downstream workflow triggering, set a repository secret named `RELEASE_PLEASE_TOKEN` with permission to create tags and releases.
+`RELEASE_PLEASE_TOKEN` is optional. If provided, `release-please` uses it instead of `GITHUB_TOKEN`, but downstream release and ClawHub publishing no longer depend on tag-triggered workflow fan-out.
 
-To enable ClawHub publishing, also set `CLAWHUB_TOKEN`.
+To enable ClawHub publishing, set `CLAWHUB_TOKEN`.
+
 
 ### Pre-commit
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -107,25 +107,23 @@ vx just package-skills
 vx just package-openclaw-skill
 ```
 
-`generate-skills.yml` 会负责为 `skills/` 下的所有 skill 生成 zip 产物，`clawhub.yml` 会在 PR 上执行 dry-run sync，并在 `main` / tag push 时同步整个 `skills/` 根目录。
+`generate-skills.yml` 会负责为 `skills/` 下的所有 skill 生成 zip 产物，`clawhub.yml` 会在 PR 上执行 dry-run sync，并在 `main` push 时同步整个 `skills/` 根目录。
 
 ### 发布自动化
 
 版本管理通过 **`release-please`** 完成：
 
-
 - 向 `main` 推送 conventional commits
 - `release-please` 创建或更新 release PR
 - 合并 release PR 后生成版本 tag 和 GitHub release 元数据
-- tag 触发的 `release.yml` workflow 发布跨平台 CLI 二进制
+- `release-please.yml` 会直接调用可复用的 `release.yml` workflow，为新生成的 tag 发布跨平台 CLI 二进制
 - `generate-skills.yml` 会为 `skills/` 下的所有 skill 生成产物
-- push/tag 触发的 `clawhub.yml` workflow 会把整个 `skills/` 根目录同步到 ClawHub，而 PR 只执行 dry-run sync
+- `clawhub.yml` 会在 PR 上执行 dry-run sync，在 `main` push 时同步 `skills/` 根目录，并且也会被 `release-please.yml` 直接调用，因此 release 时发布到 ClawHub 不再依赖第二次 tag 触发
 
+`RELEASE_PLEASE_TOKEN` 是可选的。若已配置，`release-please` 会优先使用它；但下游的 release 构建与 ClawHub 发布已经不再依赖 tag 触发的 workflow 级联。
 
-若要启用完整自动化，请配置：
+要启用 ClawHub 发布，请配置 `CLAWHUB_TOKEN`。
 
-- `RELEASE_PLEASE_TOKEN`
-- `CLAWHUB_TOKEN`
 
 ### Pre-commit
 


### PR DESCRIPTION
## Summary
- make `release-please.yml` call reusable release and ClawHub workflows directly after a release is created
- convert `release.yml` and `clawhub.yml` into reusable/manual workflows so release-time publishing no longer depends on a second tag-triggered workflow run
- update `generate-skills.yml` and both READMEs to match the new release flow

## Root cause
GitHub does not fan out new workflow runs from events created by `GITHUB_TOKEN` (except dispatch events). That made the old tag-triggered downstream release flow unreliable when `release-please` created the tag/release metadata.

## Validation
- `vx just package-skills`
- checked edited files with lints in the IDE
- verified stale docs for the old tag-triggered flow were removed