### PR TITLE
fix(ci): enable cargo-workspace plugin for release-please

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,9 +3,15 @@
   "release-type": "simple",
   "include-v-in-tag": true,
   "separate-pull-requests": false,
-  "pull-request-title-pattern": "chore: release v${version}",
-  "group-pull-request-title-pattern": "chore: release v${version}",
+  "pull-request-title-pattern": "chore${scope}: release v${version}",
+  "group-pull-request-title-pattern": "chore${scope}: release v${version}",
+  "plugins": [
+    {
+      "type": "cargo-workspace"
+    }
+  ],
   "packages": {
+
     ".": {
       "changelog-path": "crates/fpt-cli/CHANGELOG.md",
       "release-type": "simple",


### PR DESCRIPTION
## Summary

Fixes the release build failure caused by `Cargo.lock` not being updated when versions are bumped, and prevents release-please from potentially re-triggering on its own release commits.

## Root Cause

1. **`Cargo.lock` out of sync** → `--locked` build failure
   - `release-please` only updated `Cargo.toml`'s `workspace.package.version`
   - `Cargo.lock` package version fields were not refreshed
   - Tag builds with `cargo build --locked` failed because lock file didn't match manifest

2. **Custom PR title pattern** → potential re-trigger loops
   - Original pattern `"chore: release v${version}"` lacked `${scope}` placeholder
   - Mismatched release-please's default parsing rules
   - Release commits could be misidentified as new changes

## Changes

- **Enable `cargo-workspace` plugin** in `release-please-config.json`
  - Officially recommended for Rust workspaces
  - Automatically builds dependency graph and updates affected crate versions
  - **Automatically updates `Cargo.lock`** (explicitly documented)
  - Eliminates manual lock file maintenance risk

- **Restore default-compatible PR title pattern**
  - `chore${scope}: release v${version}`
  - Includes `${scope}` placeholder matching release-please default parsing
  - Ensures release commits are correctly identified

## Verification

After merge, the next release-please PR will:
1. Synchronize `Cargo.lock` version fields
2. Pass `--locked` builds on tagged releases

## Related

- Fixes error: `cannot update the lock file ... because --locked was passed`
- Prevents release-please from creating duplicate release PRs from its own commits