### PR TITLE
fix: add --locked to CI commands and update Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "fpt-cli"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/justfile
+++ b/justfile
@@ -11,13 +11,13 @@ fmt-check:
     vx cargo fmt --all -- --check
 
 check:
-    vx cargo check --workspace
+    vx cargo check --workspace --locked
 
 lint:
-    vx cargo clippy --workspace --all-targets -- -D warnings
+    vx cargo clippy --workspace --all-targets --locked -- -D warnings
 
 test:
-    vx cargo test --workspace
+    vx cargo test --workspace --locked
 
 hakari-generate:
     vx cargo hakari generate


### PR DESCRIPTION
## Problem

PR CI passed but release build failed with:
```
error: cannot update the lock file ... because --locked was passed to prevent this
```

The root cause was:
1. `Cargo.lock` had stale version (`fpt-cli 0.2.2` instead of `0.2.3`)
2. PR CI's `test`/`check`/`lint` commands did not use `--locked` flag
3. Lock file drift was only detected during release build

## Solution

- Add `--locked` flag to `check`, `lint`, and `test` commands in justfile
- This ensures lock file consistency is validated during PR CI stage
- Update `Cargo.lock` with correct version

## Testing

- All CI checks pass locally with `--locked` flag
- Build succeeds with `--locked` for all targets