### PR TITLE
fix(ci): catch stale Cargo.lock before release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,9 @@ jobs:
       - name: Install cargo-hakari
         run: vx cargo install cargo-hakari --locked
 
+      - name: Verify Cargo.lock is committed
+        run: vx just verify-lockfile
+
       - name: Run quality checks
         run: vx just ci
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "fpt-cli"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/justfile
+++ b/justfile
@@ -10,6 +10,10 @@ fmt:
 fmt-check:
     vx cargo fmt --all -- --check
 
+verify-lockfile:
+    vx cargo metadata --locked --format-version 1 --no-deps
+    git diff --exit-code -- Cargo.lock
+
 check:
     vx cargo check --workspace --locked
 
@@ -37,6 +41,7 @@ pre-commit-run:
 
 ci:
     vx just fmt-check
+    vx just verify-lockfile
     vx just hakari-check
     vx just check
     vx just lint


### PR DESCRIPTION
## What
- update `Cargo.lock` to match the current workspace package version
- add a `verify-lockfile` task in `justfile`
- run lockfile verification in PR CI before the broader quality checks

## Why
Release builds use locked Cargo commands. When `Cargo.toml` version changes but `Cargo.lock` is not committed, release-only failures occur because Cargo wants to rewrite the lockfile while `--locked` forbids it.

This change makes the repository fail earlier in PR CI instead of discovering the problem only during release.

## Validation
- `vx just test`
- `vx just build-release-target x86_64-pc-windows-msvc`
