### PR TITLE
feat: add secure fpt auth profiles

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,7 +68,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -79,7 +79,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -246,6 +246,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "byteorder-lite"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -401,6 +407,16 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
@@ -529,6 +545,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "dbus"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ab69f03cc8c4340c9c8e315114e1658e6775a9b16a04357973aa21cec22b32e"
+dependencies = [
+ "libc",
+ "libdbus-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "dbus-secret-service"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "708b509edf7889e53d7efb0ffadd994cc6c2345ccb62f55cfd6b0682165e4fa6"
+dependencies = [
+ "dbus",
+ "zeroize",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -602,7 +639,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -747,6 +784,7 @@ dependencies = [
  "fpt-domain",
  "predicates",
  "reqwest",
+ "rpassword",
  "rstest",
  "self-replace",
  "semver",
@@ -778,6 +816,7 @@ dependencies = [
  "fpt-core",
  "futures",
  "httpmock",
+ "keyring",
  "reqwest",
  "rstest",
  "serde",
@@ -1400,6 +1439,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "keyring"
+version = "3.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c"
+dependencies = [
+ "byteorder",
+ "dbus-secret-service",
+ "linux-keyutils",
+ "log",
+ "security-framework 2.11.1",
+ "security-framework 3.7.0",
+ "windows-sys 0.60.2",
+ "zeroize",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1418,6 +1473,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
+name = "libdbus-sys"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "328c4789d42200f1eeec05bd86c9c13c7f091d2ba9a6ea35acdf51f31bc0f043"
+dependencies = [
+ "pkg-config",
+]
+
+[[package]]
 name = "libredox"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1434,6 +1498,16 @@ name = "linked-hash-map"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
+name = "linux-keyutils"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83270a18e9f90d0707c41e9f35efada77b64c0e6f3f1810e71c8368a864d5590"
+dependencies = [
+ "bitflags",
+ "libc",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -2096,6 +2170,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rpassword"
+version = "7.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2da316a15f47e3d053de9cb2c439650bd8fa4aaeb9365f2e5f27f492ff73c196"
+dependencies = [
+ "libc",
+ "rtoolbox",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "rstest"
 version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2122,6 +2207,16 @@ dependencies = [
  "rustc_version",
  "syn",
  "unicode-ident",
+]
+
+[[package]]
+name = "rtoolbox"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50a0e551c1e27e1731aba276dbeaeac73f53c7cd34d1bda485d02bd1e0f36844"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2168,7 +2263,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2194,7 +2289,7 @@ dependencies = [
  "openssl-probe",
  "rustls-pki-types",
  "schannel",
- "security-framework",
+ "security-framework 3.7.0",
 ]
 
 [[package]]
@@ -2256,12 +2351,25 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -2450,7 +2558,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2587,7 +2695,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3179,7 +3287,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3538,6 +3646,7 @@ dependencies = [
  "syn",
  "tokio",
  "tracing",
+ "windows-sys 0.60.2",
  "windows-sys 0.61.2",
 ]
 
@@ -3652,6 +3761,20 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zerotrie"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -134,6 +145,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-broadcast"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix 1.1.4",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "async-lock"
 version = "3.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -153,6 +206,59 @@ dependencies = [
  "async-lock",
  "event-listener",
 ]
+
+[[package]]
+name = "async-process"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
+dependencies = [
+ "async-channel",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener",
+ "futures-lite",
+ "rustix 1.1.4",
+]
+
+[[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix 1.1.4",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
@@ -223,6 +329,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-padding"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "blocking"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
+]
+
+[[package]]
 name = "bstr"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -282,6 +410,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cbc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -314,6 +451,16 @@ dependencies = [
  "num-traits",
  "wasm-bindgen",
  "windows-link",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
 ]
 
 [[package]]
@@ -561,7 +708,16 @@ version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "708b509edf7889e53d7efb0ffadd994cc6c2345ccb62f55cfd6b0682165e4fa6"
 dependencies = [
+ "aes",
+ "block-padding",
+ "cbc",
  "dbus",
+ "fastrand",
+ "hkdf",
+ "num",
+ "once_cell",
+ "openssl",
+ "sha2",
  "zeroize",
 ]
 
@@ -588,6 +744,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -625,6 +782,33 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "endi"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
+
+[[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+ "serde",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "equivalent"
@@ -765,6 +949,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -874,6 +1073,19 @@ name = "futures-io"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "futures-macro"
@@ -1063,6 +1275,36 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "http"
@@ -1379,6 +1621,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "block-padding",
+ "generic-array",
+]
+
+[[package]]
 name = "instability"
 version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1446,8 +1698,9 @@ checksum = "eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c"
 dependencies = [
  "byteorder",
  "dbus-secret-service",
- "linux-keyutils",
  "log",
+ "openssl",
+ "secret-service",
  "security-framework 2.11.1",
  "security-framework 3.7.0",
  "windows-sys 0.60.2",
@@ -1478,6 +1731,7 @@ version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "328c4789d42200f1eeec05bd86c9c13c7f091d2ba9a6ea35acdf51f31bc0f043"
 dependencies = [
+ "cc",
  "pkg-config",
 ]
 
@@ -1498,16 +1752,6 @@ name = "linked-hash-map"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
-
-[[package]]
-name = "linux-keyutils"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83270a18e9f90d0707c41e9f35efada77b64c0e6f3f1810e71c8368a864d5590"
-dependencies = [
- "bitflags",
- "libc",
-]
 
 [[package]]
 name = "linux-raw-sys"
@@ -1570,6 +1814,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1608,16 +1861,92 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+ "memoffset",
+]
+
+[[package]]
 name = "normalize-line-endings"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c92800bd69a1eac91786bcfe9da64a897eb72911b8dc3095decbd07429e8048b"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -1736,10 +2065,67 @@ dependencies = [
 ]
 
 [[package]]
+name = "openssl"
+version = "0.10.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openssl-src"
+version = "300.6.1+3.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46eb8fb9fb3b61ce1c0f8a026c4c1a0714d3a9e138e7fbde78753ce2babc3846"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
+dependencies = [
+ "cc",
+ "libc",
+ "openssl-src",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "ordered-stream"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "parking"
@@ -1798,6 +2184,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "piper"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1833,6 +2230,20 @@ dependencies = [
  "fdeflate",
  "flate2",
  "miniz_oxide",
+]
+
+[[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix 1.1.4",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1967,7 +2378,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand",
+ "rand 0.9.2",
  "ring",
  "rustc-hash 2.1.1",
  "rustls",
@@ -2016,12 +2427,33 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2031,7 +2463,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -2350,6 +2791,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "secret-service"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4d35ad99a181be0a60ffcbe85d680d98f87bdc4d7644ade319b87076b9dbfd4"
+dependencies = [
+ "aes",
+ "cbc",
+ "futures-util",
+ "generic-array",
+ "hkdf",
+ "num",
+ "once_cell",
+ "rand 0.8.7",
+ "serde",
+ "sha2",
+ "zbus",
+]
+
+[[package]]
 name = "security-framework"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2454,6 +2914,17 @@ checksum = "a8136f1a4ea815d7eac4101cfd0b16dc0cb5e1fe1b8609dfd728058656b7badf"
 dependencies = [
  "regex",
  "serde",
+]
+
+[[package]]
+name = "serde_repr"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -3018,6 +3489,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
+name = "uds_windows"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
+dependencies = [
+ "memoffset",
+ "tempfile",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3087,6 +3569,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"
@@ -3633,6 +4121,7 @@ dependencies = [
  "linux-raw-sys 0.12.1",
  "memchr",
  "mio",
+ "num-traits",
  "proc-macro2",
  "quote",
  "regex-automata",
@@ -3684,6 +4173,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "xdg-home"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec1cdab258fb55c0da61328dc52c8764709b249011b2cad0454c72f0bf10a1f6"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "yaml-rust"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3713,6 +4212,62 @@ dependencies = [
  "quote",
  "syn",
  "synstructure",
+]
+
+[[package]]
+name = "zbus"
+version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb97012beadd29e654708a0fdb4c84bc046f537aecfde2c3ee0a9e4b4d48c725"
+dependencies = [
+ "async-broadcast",
+ "async-process",
+ "async-recursion",
+ "async-trait",
+ "enumflags2",
+ "event-listener",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "hex",
+ "nix",
+ "ordered-stream",
+ "rand 0.8.7",
+ "serde",
+ "serde_repr",
+ "sha1",
+ "static_assertions",
+ "tracing",
+ "uds_windows",
+ "windows-sys 0.52.0",
+ "xdg-home",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "267db9407081e90bbfa46d841d3cbc60f59c0351838c4bc65199ecd79ab1983e"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zbus_names"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b9b1fef7d021261cc16cba64c351d291b715febe0fa10dc3a443ac5a5022e6c"
+dependencies = [
+ "serde",
+ "static_assertions",
+ "zvariant",
 ]
 
 [[package]]
@@ -3860,4 +4415,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7a1c0af6e5d8d1363f4994b7a091ccf963d8b694f7da5b0b9cceb82da2c0a6"
 dependencies = [
  "zune-core",
+]
+
+[[package]]
+name = "zvariant"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2084290ab9a1c471c38fc524945837734fbf124487e105daec2bb57fd48c81fe"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "static_assertions",
+ "zvariant_derive",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73e2ba546bda683a90652bac4a279bc146adad1386f25379cf73200d2002c449"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c51bcff7cc3dbb5055396bcf774748c3dab426b4b8659046963523cee4808340"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,8 +20,10 @@ clap = { version = "4.5.32", features = ["derive"] }
 flate2 = "1.1.0"
 futures = "0.3.31"
 httpmock = "0.8.0"
+keyring = { version = "3.6.2", default-features = false, features = ["apple-native", "linux-native-sync-persistent", "windows-native"] }
 predicates = "3.1.3"
 reqwest = { version = "0.12.14", default-features = false, features = ["json", "rustls-tls-native-roots"] }
+rpassword = "7.5.4"
 rstest = "0.26.0"
 self-replace = "1.5.0"
 semver = "1.0.26"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ clap = { version = "4.5.32", features = ["derive"] }
 flate2 = "1.1.0"
 futures = "0.3.31"
 httpmock = "0.8.0"
-keyring = { version = "3.6.2", default-features = false, features = ["apple-native", "linux-native-sync-persistent", "windows-native"] }
+keyring = { version = "3.6.2", default-features = false, features = ["apple-native", "crypto-rust", "sync-secret-service", "vendored", "windows-native"] }
 predicates = "3.1.3"
 reqwest = { version = "0.12.14", default-features = false, features = ["json", "rustls-tls-native-roots"] }
 rpassword = "7.5.4"

--- a/README.md
+++ b/README.md
@@ -61,11 +61,11 @@ Prebuilt release binaries are published for:
 Install the latest release over HTTPS:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/loonghao/fpt-cli/main/scripts/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/dcc-mcp/fpt-cli/main/scripts/install.sh | sh
 ```
 
 ```powershell
-powershell -ExecutionPolicy Bypass -c "irm https://raw.githubusercontent.com/loonghao/fpt-cli/main/scripts/install.ps1 | iex"
+powershell -ExecutionPolicy Bypass -c "irm https://raw.githubusercontent.com/dcc-mcp/fpt-cli/main/scripts/install.ps1 | iex"
 ```
 
 Optional installer environment variables:

--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ The CLI prefers the `FPT_*` prefix and also supports `SG_*` as a fallback when `
 - `FPT_PASSWORD` / `SG_PASSWORD`
 - `FPT_AUTH_TOKEN` / `SG_AUTH_TOKEN`: optional when the site uses 2FA
 - `FPT_SESSION_TOKEN` / `SG_SESSION_TOKEN`
+- `FPT_PROFILE` / `SG_PROFILE`: secure local credential profile created by `fpt auth login`
 - `FPT_API_VERSION` / `SG_API_VERSION` (optional, default `v1.1`)
 
 ### Authentication modes
@@ -167,6 +168,21 @@ The CLI prefers the `FPT_*` prefix and also supports `SG_*` as a fallback when `
 - **script**: uses `script_name + script_key` with the `client_credentials` flow
 - **user_password**: uses `username + password` with the `password` grant
 - **session_token**: uses an existing `session_token` with the `session_token` grant
+
+### Secure local user profile (recommended for agents)
+
+For Autodesk Identity/Oxygen sites, create a profile on the user's workstation. `--open-browser`
+opens the FPT site so the user can sign in and complete any required PAT setup; secrets are then
+prompted locally and saved only in the operating system credential store.
+
+```bash
+fpt auth login --profile gamedemo --site https://gamedemo.shotgrid.autodesk.com \
+  --auth-mode user-password --username artist@example.com --open-browser
+fpt user current --profile gamedemo
+fpt auth logout --profile gamedemo
+```
+
+Agents and adapters receive only `FPT_PROFILE=gamedemo`; they never receive the password, PAT, or session token.
 
 If `--auth-mode` is not provided explicitly, the CLI infers it from the available inputs:
 
@@ -186,6 +202,9 @@ fpt inspect list --output json
 fpt auth test --site https://example.shotgrid.autodesk.com --auth-mode script --script-name bot --script-key xxx
 fpt auth test --site https://example.shotgrid.autodesk.com --auth-mode user-password --username user@example.com --password secret
 fpt auth test --site https://example.shotgrid.autodesk.com --auth-mode session-token --session-token xxx
+fpt auth login --profile gamedemo --site https://gamedemo.shotgrid.autodesk.com --auth-mode user-password --username artist@example.com --open-browser
+fpt user current --profile gamedemo
+fpt auth logout --profile gamedemo
 
 # Server
 fpt server info --site ...

--- a/README_zh.md
+++ b/README_zh.md
@@ -61,12 +61,12 @@ vx just capabilities
 可通过 HTTPS 直接安装最新版本：
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/loonghao/fpt-cli/main/scripts/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/dcc-mcp/fpt-cli/main/scripts/install.sh | sh
 
 ```
 
 ```powershell
-powershell -ExecutionPolicy Bypass -c "irm https://raw.githubusercontent.com/loonghao/fpt-cli/main/scripts/install.ps1 | iex"
+powershell -ExecutionPolicy Bypass -c "irm https://raw.githubusercontent.com/dcc-mcp/fpt-cli/main/scripts/install.ps1 | iex"
 
 ```
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -160,6 +160,7 @@ CLI 默认优先使用 `FPT_*` 前缀；当 `FPT_*` 缺失时，也支持回退�
 - `FPT_PASSWORD` / `SG_PASSWORD`
 - `FPT_AUTH_TOKEN` / `SG_AUTH_TOKEN`：站点启用 2FA 时可选
 - `FPT_SESSION_TOKEN` / `SG_SESSION_TOKEN`
+- `FPT_PROFILE` / `SG_PROFILE`：由 `fpt auth login` 创建的安全本地凭据 profile
 - `FPT_API_VERSION` / `SG_API_VERSION`（可选，默认 `v1.1`）
 
 ### 认证模式
@@ -167,6 +168,20 @@ CLI 默认优先使用 `FPT_*` 前缀；当 `FPT_*` 缺失时，也支持回退�
 - **script**：使用 `script_name + script_key` 走 `client_credentials`
 - **user_password**：使用 `username + password` 走 `password` grant
 - **session_token**：使用已有 `session_token` 走 `session_token` grant
+
+### 安全本地用户 Profile（Agent 推荐）
+
+对于 Autodesk Identity/Oxygen 站点，在用户工作站创建 profile。`--open-browser` 会打开 FPT
+站点供用户登录并完成所需的 PAT 配置；随后仅在本地终端读取敏感信息，并将其保存到操作系统凭据库。
+
+```bash
+fpt auth login --profile gamedemo --site https://gamedemo.shotgrid.autodesk.com \
+  --auth-mode user-password --username artist@example.com --open-browser
+fpt user current --profile gamedemo
+fpt auth logout --profile gamedemo
+```
+
+Agent 和适配器只接收 `FPT_PROFILE=gamedemo`，不会获得密码、PAT 或 session token。
 
 如果没有显式传入 `--auth-mode`，CLI 会基于已有输入自动推断：
 
@@ -186,6 +201,9 @@ fpt inspect list --output json
 fpt auth test --site https://example.shotgrid.autodesk.com --auth-mode script --script-name bot --script-key xxx
 fpt auth test --site https://example.shotgrid.autodesk.com --auth-mode user-password --username user@example.com --password secret
 fpt auth test --site https://example.shotgrid.autodesk.com --auth-mode session-token --session-token xxx
+fpt auth login --profile gamedemo --site https://gamedemo.shotgrid.autodesk.com --auth-mode user-password --username artist@example.com --open-browser
+fpt user current --profile gamedemo
+fpt auth logout --profile gamedemo
 
 # 服务器
 fpt server info --site ...

--- a/crates/fpt-cli/Cargo.toml
+++ b/crates/fpt-cli/Cargo.toml
@@ -15,6 +15,7 @@ flate2 = { workspace = true }
 fpt-core = { path = "../fpt-core" }
 fpt-domain = { path = "../fpt-domain" }
 reqwest = { workspace = true }
+rpassword = { workspace = true }
 self-replace = { workspace = true }
 semver = { workspace = true }
 serde = { workspace = true }

--- a/crates/fpt-cli/src/cli/commands.rs
+++ b/crates/fpt-cli/src/cli/commands.rs
@@ -172,6 +172,25 @@ pub enum InspectCommands {
 #[derive(Debug, Subcommand)]
 pub enum AuthCommands {
     Test,
+    #[command(
+        name = "login",
+        about = "Create or replace a local credential profile in the system credential store"
+    )]
+    Login(AuthLoginArgs),
+    #[command(
+        name = "logout",
+        about = "Remove a local credential profile and its secure credentials"
+    )]
+    Logout,
+}
+
+#[derive(Debug, Args, Clone, Default)]
+pub struct AuthLoginArgs {
+    #[arg(
+        long,
+        help = "Open the Flow Production Tracking site before prompting for local credentials"
+    )]
+    pub open_browser: bool,
 }
 
 #[derive(Debug, Subcommand)]

--- a/crates/fpt-cli/src/cli/connection.rs
+++ b/crates/fpt-cli/src/cli/connection.rs
@@ -5,6 +5,13 @@ use super::common::AuthModeArg;
 
 #[derive(Debug, Args, Clone, Default)]
 pub struct ConnectionArgs {
+    #[arg(
+        long,
+        global = true,
+        help = "Use a secure local FPT credential profile"
+    )]
+    pub profile: Option<String>,
+
     #[arg(long, global = true)]
     pub site: Option<String>,
 
@@ -36,6 +43,7 @@ pub struct ConnectionArgs {
 impl From<ConnectionArgs> for ConnectionOverrides {
     fn from(value: ConnectionArgs) -> Self {
         Self {
+            profile: value.profile,
             site: value.site,
             auth_mode: value.auth_mode.map(Into::into),
             script_name: value.script_name,

--- a/crates/fpt-cli/src/config.rs
+++ b/crates/fpt-cli/src/config.rs
@@ -1,9 +1,16 @@
 use crate::cli::{ConfigClearArgs, ConfigCommands, ConfigSetArgs};
 use fpt_core::{AppError, Result};
 use fpt_domain::{
-    PersistedConnectionConfig, config_file_path, load_persisted_config, save_persisted_config,
+    AuthMode, ConnectionOverrides, PersistedConnectionConfig, PersistedConnectionProfile,
+    SecureProfileSecrets, config_file_path, load_persisted_config, remove_profile,
+    save_persisted_config, save_profile,
 };
 use serde_json::{Value, json};
+use std::{
+    env,
+    io::{self, Write},
+    process::Command,
+};
 
 pub fn run(command: ConfigCommands) -> Result<Value> {
     match command {
@@ -20,13 +27,163 @@ pub fn run(command: ConfigCommands) -> Result<Value> {
     }
 }
 
+pub fn login(overrides: ConnectionOverrides, open_browser: bool) -> Result<Value> {
+    let profile = required_login_value(overrides.profile.as_deref(), "--profile")?;
+    let env_site = env_value("FPT_SITE", "SG_SITE");
+    let site = required_login_value(overrides.site.as_deref().or(env_site.as_deref()), "--site")?;
+    let env_auth_mode = env_value("FPT_AUTH_MODE", "SG_AUTH_MODE");
+    let auth_mode = overrides
+        .auth_mode
+        .or(env_auth_mode.as_deref().map(str::parse).transpose()?)
+        .unwrap_or(AuthMode::UserPassword);
+
+    if open_browser {
+        open_site(&site)?;
+    }
+
+    let (script_name, username, secrets) = match auth_mode {
+        AuthMode::Script => {
+            let env_script_name = env_value("FPT_SCRIPT_NAME", "SG_SCRIPT_NAME");
+            let script_name = required_login_value(
+                overrides
+                    .script_name
+                    .as_deref()
+                    .or(env_script_name.as_deref()),
+                "--script-name",
+            )?;
+            let script_key = prompt_secret("FPT script key: ")?;
+            (
+                Some(script_name),
+                None,
+                SecureProfileSecrets {
+                    script_key: Some(script_key),
+                    ..Default::default()
+                },
+            )
+        }
+        AuthMode::UserPassword => {
+            let env_username = env_value("FPT_USERNAME", "SG_USERNAME");
+            let username = required_login_value(
+                overrides.username.as_deref().or(env_username.as_deref()),
+                "--username",
+            )?;
+            let password = prompt_secret("FPT legacy passphrase: ")?;
+            let auth_token = prompt_optional_secret(
+                "FPT personal access token or MFA code (leave empty when unused): ",
+            )?;
+            (
+                None,
+                Some(username),
+                SecureProfileSecrets {
+                    password: Some(password),
+                    auth_token,
+                    ..Default::default()
+                },
+            )
+        }
+        AuthMode::SessionToken => {
+            let session_token = prompt_secret("FPT session token: ")?;
+            (
+                None,
+                None,
+                SecureProfileSecrets {
+                    session_token: Some(session_token),
+                    ..Default::default()
+                },
+            )
+        }
+    };
+    let path = save_profile(
+        &profile,
+        PersistedConnectionProfile {
+            site: site.clone(),
+            auth_mode,
+            script_name,
+            username,
+            api_version: overrides.api_version,
+        },
+        secrets,
+    )?;
+    Ok(json!({
+        "command": "auth.login",
+        "profile": profile,
+        "site": site,
+        "auth_mode": auth_mode,
+        "credential_store": "system_keyring",
+        "browser_opened": open_browser,
+        "next_step": "Run `fpt user current --profile <profile>` to verify the authenticated user.",
+        "config_path": path.display().to_string(),
+    }))
+}
+
+pub fn logout(profile: Option<&str>) -> Result<Value> {
+    let profile = required_login_value(profile, "--profile")?;
+    let path = remove_profile(&profile)?;
+    Ok(json!({
+        "command": "auth.logout",
+        "profile": profile,
+        "config_path": path.display().to_string(),
+    }))
+}
+
+fn required_login_value(value: Option<&str>, flag: &str) -> Result<String> {
+    value
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+        .ok_or_else(|| AppError::invalid_input(format!("`auth login` requires {flag}")))
+}
+
+fn prompt_secret(prompt: &str) -> Result<String> {
+    let value = rpassword::prompt_password(prompt).map_err(|error| {
+        AppError::internal(format!("could not read secure terminal input: {error}"))
+    })?;
+    required_login_value(Some(&value), "a non-empty secret")
+}
+
+fn prompt_optional_secret(prompt: &str) -> Result<Option<String>> {
+    let value = rpassword::prompt_password(prompt).map_err(|error| {
+        AppError::internal(format!("could not read secure terminal input: {error}"))
+    })?;
+    Ok((!value.trim().is_empty()).then_some(value))
+}
+
+fn env_value(primary: &str, fallback: &str) -> Option<String> {
+    env::var(primary)
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .or_else(|| {
+            env::var(fallback)
+                .ok()
+                .filter(|value| !value.trim().is_empty())
+        })
+}
+
+fn open_site(site: &str) -> Result<()> {
+    let mut command = if cfg!(target_os = "windows") {
+        Command::new("explorer.exe")
+    } else if cfg!(target_os = "macos") {
+        Command::new("open")
+    } else {
+        Command::new("xdg-open")
+    };
+    command.arg(site);
+    command.status().map_err(|error| {
+        AppError::internal(format!("could not open the default browser: {error}"))
+            .with_operation("open_auth_browser")
+            .with_hint("Open the Flow Production Tracking site manually, then rerun without --open-browser.")
+    })?;
+    io::stderr().flush().ok();
+    Ok(())
+}
+
 fn get_config() -> Result<Value> {
     let path = config_file_path()?;
     let config = load_persisted_config()?;
     Ok(json!({
         "command": "config.get",
         "path": path.display().to_string(),
-        "config": config,
+        "config": config_diagnostics(&config),
     }))
 }
 
@@ -70,7 +227,7 @@ fn set_config(args: ConfigSetArgs) -> Result<Value> {
     Ok(json!({
         "command": "config.set",
         "path": path.display().to_string(),
-        "config": config,
+        "config": config_diagnostics(&config),
     }))
 }
 
@@ -145,8 +302,23 @@ fn clear_config(args: ConfigClearArgs) -> Result<Value> {
     Ok(json!({
         "command": "config.clear",
         "path": path.display().to_string(),
-        "config": config,
+        "config": config_diagnostics(&config),
     }))
+}
+
+fn config_diagnostics(config: &PersistedConnectionConfig) -> Value {
+    json!({
+        "site": config.site,
+        "auth_mode": config.auth_mode,
+        "script_name": config.script_name,
+        "script_key": config.script_key.as_ref().map(|_| "<redacted>"),
+        "username": config.username,
+        "password": config.password.as_ref().map(|_| "<redacted>"),
+        "auth_token": config.auth_token.as_ref().map(|_| "<redacted>"),
+        "session_token": config.session_token.as_ref().map(|_| "<redacted>"),
+        "api_version": config.api_version,
+        "profiles": config.profiles,
+    })
 }
 
 fn has_any_set_arg(args: &ConfigSetArgs) -> bool {

--- a/crates/fpt-cli/src/runner.rs
+++ b/crates/fpt-cli/src/runner.rs
@@ -24,6 +24,8 @@ pub async fn run(cli: Cli) -> Result<Value> {
         },
         Commands::Auth(command) => match command {
             AuthCommands::Test => app.auth_test(connection).await,
+            AuthCommands::Login(args) => config::login(connection, args.open_browser),
+            AuthCommands::Logout => config::logout(connection.profile.as_deref()),
         },
         Commands::Server(command) => match command {
             ServerCommands::Info => app.server_info(connection).await,

--- a/crates/fpt-cli/src/self_update.rs
+++ b/crates/fpt-cli/src/self_update.rs
@@ -14,7 +14,7 @@ use tar::Archive;
 use tempfile::tempdir;
 use zip::ZipArchive;
 
-const DEFAULT_REPOSITORY: &str = "loonghao/fpt-cli";
+const DEFAULT_REPOSITORY: &str = "dcc-mcp/fpt-cli";
 /// Environment variable for overriding the GitHub repository used by `self-update`.
 const ENV_FPT_UPDATE_REPOSITORY: &str = "FPT_UPDATE_REPOSITORY";
 const CHECKSUM_ASSET_NAME: &str = "fpt-checksums.txt";
@@ -169,7 +169,7 @@ fn split_repository(repository: &str) -> Result<(String, String)> {
             .with_operation("split_repository")
             .with_invalid_field("repository")
             .with_received_value(repository)
-            .with_expected_shape("`owner/repo`, for example `loonghao/fpt-cli`")
+            .with_expected_shape("`owner/repo`, for example `dcc-mcp/fpt-cli`")
     };
 
     let (owner, repo) = repository.split_once('/').ok_or_else(bad_format)?;

--- a/crates/fpt-cli/tests/cli_contract_tests.rs
+++ b/crates/fpt-cli/tests/cli_contract_tests.rs
@@ -69,6 +69,19 @@ fn inspect_auth_test_mentions_session_token_mode() {
 }
 
 #[test]
+fn inspect_auth_login_mentions_secure_profiles() {
+    let mut command = Command::cargo_bin("fpt").expect("fpt binary");
+    command.args(["inspect", "command", "auth.login", "--output", "json"]);
+    command
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("system_keyring"))
+        .stdout(predicate::str::contains(
+            "operating system credential store",
+        ));
+}
+
+#[test]
 fn inspect_entity_find_mentions_structured_search() {
     let mut command = Command::cargo_bin("fpt").expect("binary exists");
     command.args(["inspect", "command", "entity.find", "--output", "json"]);

--- a/crates/fpt-domain/Cargo.toml
+++ b/crates/fpt-domain/Cargo.toml
@@ -10,6 +10,7 @@ rust-version = { workspace = true }
 async-trait = { workspace = true }
 fpt-core = { path = "../fpt-core" }
 futures = { workspace = true }
+keyring = { workspace = true }
 reqwest = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/fpt-domain/src/capability.rs
+++ b/crates/fpt-domain/src/capability.rs
@@ -24,6 +24,8 @@ static COMMANDS: &[CommandSpec] = &[
     core::INSPECT_LIST_SPEC,
     // Auth
     auth::AUTH_TEST_SPEC,
+    auth::AUTH_LOGIN_SPEC,
+    auth::AUTH_LOGOUT_SPEC,
     // Server
     server::SERVER_INFO_SPEC,
     // Schema

--- a/crates/fpt-domain/src/capability/auth.rs
+++ b/crates/fpt-domain/src/capability/auth.rs
@@ -25,3 +25,43 @@ pub const AUTH_TEST_SPEC: CommandSpec = CommandSpec {
     examples: AUTH_TEST_EXAMPLES,
     notes: AUTH_NOTES,
 };
+
+const AUTH_LOGIN_EXAMPLES: &[&str] = &[
+    "fpt auth login --profile gamedemo --site https://gamedemo.shotgrid.autodesk.com --auth-mode user-password --username artist@example.com --open-browser",
+    "fpt user current --profile gamedemo",
+];
+const AUTH_LOGIN_NOTES: &[&str] = &[
+    "Prompts for secrets locally and stores them in the operating system credential store",
+    "The browser option guides Autodesk Identity users through site login and PAT setup; it does not expose browser cookies or tokens to the agent",
+    "Use `fpt user current --profile <name>` to prove the effective ShotGrid identity",
+];
+
+pub const AUTH_LOGIN_SPEC: CommandSpec = CommandSpec {
+    name: "auth.login",
+    summary: "Create a secure local user or service credential profile",
+    risk: RiskLevel::Write,
+    implemented: true,
+    supports_dry_run: false,
+    preferred_transport: "system_keyring",
+    fallback_transport: None,
+    input: "--profile, --site, auth mode, and non-secret identity fields; secrets are prompted locally",
+    output: "json",
+    examples: AUTH_LOGIN_EXAMPLES,
+    notes: AUTH_LOGIN_NOTES,
+};
+
+const AUTH_LOGOUT_EXAMPLES: &[&str] = &["fpt auth logout --profile gamedemo"];
+
+pub const AUTH_LOGOUT_SPEC: CommandSpec = CommandSpec {
+    name: "auth.logout",
+    summary: "Remove a secure local credential profile",
+    risk: RiskLevel::Write,
+    implemented: true,
+    supports_dry_run: false,
+    preferred_transport: "system_keyring",
+    fallback_transport: None,
+    input: "--profile <name>",
+    output: "json",
+    examples: AUTH_LOGOUT_EXAMPLES,
+    notes: &["Deletes both local profile metadata and the matching system credential entry"],
+};

--- a/crates/fpt-domain/src/capability/self_update.rs
+++ b/crates/fpt-domain/src/capability/self_update.rs
@@ -28,8 +28,9 @@ const CONFIG_CLEAR_EXAMPLES: &[&str] = &[
 
 const CONFIG_NOTES: &[&str] = &[
     "Persisted config is used when command-line flags and environment variables are not provided",
-    "Configuration is stored in a local JSON file and can include site, auth mode, credentials, and API version",
-    "Use `config clear` to remove saved secrets or other persisted values",
+    "Legacy configuration is stored in a local JSON file; use `auth login --profile` for new secrets",
+    "Configuration output redacts any legacy secrets",
+    "Use `config clear` to remove legacy values or `auth logout --profile` to remove secure profiles",
 ];
 
 pub const SELF_UPDATE_SPEC: CommandSpec = CommandSpec {

--- a/crates/fpt-domain/src/config.rs
+++ b/crates/fpt-domain/src/config.rs
@@ -1,6 +1,6 @@
 use fpt_core::{AppError, Result};
 use serde::{Deserialize, Serialize};
-use std::{env, fs, path::PathBuf, str::FromStr};
+use std::{collections::BTreeMap, env, fs, path::PathBuf, str::FromStr};
 
 const DEFAULT_API_VERSION: &str = "v1.1";
 const CONFIG_FILE_NAME: &str = "config.json";
@@ -54,6 +54,7 @@ impl FromStr for AuthMode {
 
 #[derive(Debug, Clone, Default)]
 pub struct ConnectionOverrides {
+    pub profile: Option<String>,
     pub site: Option<String>,
     pub auth_mode: Option<AuthMode>,
     pub script_name: Option<String>,
@@ -85,6 +86,34 @@ pub struct PersistedConnectionConfig {
     pub session_token: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub api_version: Option<String>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub profiles: BTreeMap<String, PersistedConnectionProfile>,
+}
+
+/// Non-secret connection data for an agent-selectable local profile.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PersistedConnectionProfile {
+    pub site: String,
+    pub auth_mode: AuthMode,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub script_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub username: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub api_version: Option<String>,
+}
+
+/// Secrets are kept in the operating system credential store, never in config.json.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct SecureProfileSecrets {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub script_key: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub password: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub auth_token: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub session_token: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -134,12 +163,21 @@ pub struct ConnectionSummary {
     pub auth_mode: AuthMode,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub principal: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub profile: Option<String>,
     pub api_version: String,
 }
 
 impl ConnectionSettings {
     pub fn resolve(overrides: ConnectionOverrides) -> Result<Self> {
         let persisted = load_persisted_config()?;
+        let profile_name = overrides
+            .profile
+            .clone()
+            .or_else(|| env_var_compat("FPT_PROFILE", "SG_PROFILE"));
+        if let Some(profile_name) = profile_name {
+            return resolve_profile(&persisted, &profile_name);
+        }
         let env_site = env_var_compat("FPT_SITE", "SG_SITE");
         let env_auth_mode = env_var_compat("FPT_AUTH_MODE", "SG_AUTH_MODE");
         let env_script_name = env_var_compat("FPT_SCRIPT_NAME", "SG_SCRIPT_NAME");
@@ -269,9 +307,163 @@ impl ConnectionSettings {
             site: self.site.clone(),
             auth_mode: self.auth_mode(),
             principal: self.credentials.principal(),
+            profile: None,
             api_version: self.api_version.clone(),
         }
     }
+}
+
+fn resolve_profile(
+    config: &PersistedConnectionConfig,
+    profile_name: &str,
+) -> Result<ConnectionSettings> {
+    let profile = config.profiles.get(profile_name).ok_or_else(|| {
+        AppError::invalid_input(format!("unknown FPT credential profile `{profile_name}`"))
+            .with_operation("resolve_connection_profile")
+            .with_invalid_field("profile")
+            .with_hint("Create it interactively with `fpt auth login --profile <name> --site <url> --auth-mode user-password`.")
+    })?;
+    let secrets = load_profile_secrets(profile_name)?;
+    let credentials = match profile.auth_mode {
+        AuthMode::Script => Credentials::Script {
+            script_name: required_profile_value(
+                profile.script_name.as_deref(),
+                profile_name,
+                "script_name",
+            )?,
+            script_key: required_secret_value(secrets.script_key, profile_name, "script key")?,
+        },
+        AuthMode::UserPassword => Credentials::UserPassword {
+            username: required_profile_value(
+                profile.username.as_deref(),
+                profile_name,
+                "username",
+            )?,
+            password: required_secret_value(secrets.password, profile_name, "legacy passphrase")?,
+            auth_token: secrets.auth_token.filter(|value| !value.trim().is_empty()),
+        },
+        AuthMode::SessionToken => Credentials::SessionToken {
+            session_token: required_secret_value(
+                secrets.session_token,
+                profile_name,
+                "session token",
+            )?,
+        },
+    };
+
+    Ok(ConnectionSettings {
+        site: profile.site.trim_end_matches('/').to_string(),
+        credentials,
+        api_version: api_version_or_default(profile.api_version.as_deref()),
+    })
+}
+
+pub fn save_profile(
+    profile_name: &str,
+    profile: PersistedConnectionProfile,
+    secrets: SecureProfileSecrets,
+) -> Result<PathBuf> {
+    validate_profile_name(profile_name)?;
+    let serialized = serde_json::to_string(&secrets).map_err(|error| {
+        AppError::internal(format!(
+            "could not serialize secure profile secrets: {error}"
+        ))
+        .with_operation("serialize_profile_secrets")
+    })?;
+    let entry = keyring::Entry::new("dcc-mcp/fpt-cli", profile_name).map_err(|error| {
+        AppError::internal(format!(
+            "could not access the system credential store: {error}"
+        ))
+        .with_operation("open_profile_keyring")
+    })?;
+    entry.set_password(&serialized).map_err(|error| {
+        AppError::internal(format!(
+            "could not save secure profile credentials: {error}"
+        ))
+        .with_operation("save_profile_secrets")
+        .with_hint("Unlock the operating system credential store and retry.")
+    })?;
+
+    let mut config = load_persisted_config()?;
+    config.profiles.insert(profile_name.to_string(), profile);
+    save_persisted_config(&config)
+}
+
+pub fn remove_profile(profile_name: &str) -> Result<PathBuf> {
+    validate_profile_name(profile_name)?;
+    let mut config = load_persisted_config()?;
+    if config.profiles.remove(profile_name).is_none() {
+        return Err(AppError::invalid_input(format!(
+            "unknown FPT credential profile `{profile_name}`"
+        ))
+        .with_operation("remove_connection_profile")
+        .with_invalid_field("profile"));
+    }
+    let entry = keyring::Entry::new("dcc-mcp/fpt-cli", profile_name).map_err(|error| {
+        AppError::internal(format!(
+            "could not access the system credential store: {error}"
+        ))
+        .with_operation("open_profile_keyring")
+    })?;
+    let _ = entry.delete_credential();
+    save_persisted_config(&config)
+}
+
+fn load_profile_secrets(profile_name: &str) -> Result<SecureProfileSecrets> {
+    let entry = keyring::Entry::new("dcc-mcp/fpt-cli", profile_name).map_err(|error| {
+        AppError::internal(format!(
+            "could not access the system credential store: {error}"
+        ))
+        .with_operation("open_profile_keyring")
+    })?;
+    let serialized = entry.get_password().map_err(|error| {
+        AppError::invalid_input(format!(
+            "secure credentials for FPT profile `{profile_name}` are unavailable: {error}"
+        ))
+        .with_operation("load_profile_secrets")
+        .with_hint("Run `fpt auth login --profile <name> ...` again on this machine.")
+    })?;
+    serde_json::from_str(&serialized).map_err(|error| {
+        AppError::invalid_input(format!(
+            "secure credentials for FPT profile `{profile_name}` are invalid: {error}"
+        ))
+        .with_operation("parse_profile_secrets")
+    })
+}
+
+fn required_profile_value(value: Option<&str>, profile_name: &str, field: &str) -> Result<String> {
+    value
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+        .ok_or_else(|| {
+            AppError::invalid_input(format!("FPT profile `{profile_name}` is missing {field}"))
+                .with_operation("resolve_connection_profile")
+        })
+}
+
+fn required_secret_value(value: Option<String>, profile_name: &str, field: &str) -> Result<String> {
+    value
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| {
+            AppError::invalid_input(format!(
+                "FPT profile `{profile_name}` is missing secure {field}"
+            ))
+            .with_operation("resolve_connection_profile")
+            .with_hint("Run `fpt auth login --profile <name> ...` again on this machine.")
+        })
+}
+
+fn validate_profile_name(profile_name: &str) -> Result<()> {
+    if profile_name.trim().is_empty() || profile_name.len() > 128 {
+        return Err(AppError::invalid_input(
+            "profile must contain 1-128 non-whitespace characters",
+        )
+        .with_operation("validate_connection_profile")
+        .with_invalid_field("profile"));
+    }
+    Ok(())
 }
 
 pub fn api_version_or_default(value: Option<&str>) -> String {

--- a/crates/fpt-domain/src/lib.rs
+++ b/crates/fpt-domain/src/lib.rs
@@ -9,7 +9,8 @@ pub mod transport;
 pub use app::App;
 pub use config::{
     AuthMode, ConnectionOverrides, ConnectionSettings, Credentials, PersistedConnectionConfig,
-    api_version_or_default, config_file_path, load_persisted_config, save_persisted_config,
+    PersistedConnectionProfile, SecureProfileSecrets, api_version_or_default, config_file_path,
+    load_persisted_config, remove_profile, save_persisted_config, save_profile,
 };
 pub use filter_dsl::parse_filter_dsl;
 pub use transport::{

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -2,7 +2,7 @@
 param(
     [string]$Version = $env:FPT_INSTALL_VERSION,
     [string]$InstallDir = $(if ($env:FPT_INSTALL_DIR) { $env:FPT_INSTALL_DIR } else { Join-Path $env:USERPROFILE ".fpt\bin" }),
-    [string]$Repository = $(if ($env:FPT_INSTALL_REPOSITORY) { $env:FPT_INSTALL_REPOSITORY } else { "loonghao/fpt-cli" })
+    [string]$Repository = $(if ($env:FPT_INSTALL_REPOSITORY) { $env:FPT_INSTALL_REPOSITORY } else { "dcc-mcp/fpt-cli" })
 )
 
 Set-StrictMode -Version Latest

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env sh
 set -eu
 
-REPOSITORY="${FPT_INSTALL_REPOSITORY:-loonghao/fpt-cli}"
+REPOSITORY="${FPT_INSTALL_REPOSITORY:-dcc-mcp/fpt-cli}"
 INSTALL_DIR="${FPT_INSTALL_DIR:-$HOME/.local/bin}"
 VERSION="${1:-${FPT_INSTALL_VERSION:-latest}}"
 

--- a/skills/fpt-cli/references/install-and-auth.md
+++ b/skills/fpt-cli/references/install-and-auth.md
@@ -75,6 +75,7 @@ vx just test
 | `FPT_PASSWORD` | required | `user_password` | ShotGrid user password |
 | `FPT_AUTH_TOKEN` | optional | `user_password` | One-time 2FA token when the site enforces MFA |
 | `FPT_SESSION_TOKEN` | required | `session_token` | Pre-obtained session token |
+| `FPT_PROFILE` | required | secure profile | Profile name created with `fpt auth login`; takes precedence over raw credentials |
 
 ### Auth modes
 - `script` — requires `FPT_SCRIPT_NAME` + `FPT_SCRIPT_KEY`
@@ -86,6 +87,17 @@ Validate credentials before running entity or schema commands.
 
 ```bash
 fpt auth test --output json
+```
+
+### Secure local profile for agent use
+
+Run this in the user's local terminal. The command prompts for secrets without echoing them and stores them in the system credential store. `--open-browser` is a user-login/PAT setup aid, not an OAuth callback.
+
+```bash
+fpt auth login --profile gamedemo --site https://gamedemo.shotgrid.autodesk.com \
+  --auth-mode user-password --username artist@example.com --open-browser
+fpt user current --profile gamedemo --output json
+fpt auth logout --profile gamedemo
 ```
 
 ### Example: script auth (bash)
@@ -150,3 +162,4 @@ fpt auth test --output pretty-json
 - Treat `FPT_*` as the primary namespace.
 - Use `SG_*` only as fallback compatibility inputs.
 - Add `FPT_AUTH_TOKEN` when the ShotGrid site requires 2FA.
+- For agent workloads, prefer `FPT_PROFILE`; never put a password, PAT, or session token in agent messages or MCP metadata.

--- a/skills/fpt-cli/references/install-and-auth.md
+++ b/skills/fpt-cli/references/install-and-auth.md
@@ -21,8 +21,8 @@ Release asset names:
 export FPT_VERSION="v0.1.0"
 export FPT_INSTALL_DIR="${FPT_INSTALL_DIR:-$HOME/.local/bin}"
 export FPT_ARCHIVE="fpt-${FPT_VERSION}-x86_64-unknown-linux-gnu.tar.gz"
-curl -fLO "https://github.com/loonghao/fpt-cli/releases/download/${FPT_VERSION}/${FPT_ARCHIVE}"
-curl -fLO "https://github.com/loonghao/fpt-cli/releases/download/${FPT_VERSION}/fpt-checksums.txt"
+curl -fLO "https://github.com/dcc-mcp/fpt-cli/releases/download/${FPT_VERSION}/${FPT_ARCHIVE}"
+curl -fLO "https://github.com/dcc-mcp/fpt-cli/releases/download/${FPT_VERSION}/fpt-checksums.txt"
 sha256sum -c --ignore-missing fpt-checksums.txt
 tar -xzf "${FPT_ARCHIVE}"
 mkdir -p "$FPT_INSTALL_DIR"
@@ -36,7 +36,7 @@ $FptVersion = "v0.1.0"
 $InstallDir = if ($env:FPT_INSTALL_DIR) { $env:FPT_INSTALL_DIR } else { Join-Path $env:USERPROFILE ".fpt\bin" }
 $Archive = "fpt-$FptVersion-x86_64-pc-windows-msvc.zip"
 $ExtractDir = Join-Path $env:TEMP "fpt-extract"
-Invoke-WebRequest -Uri "https://github.com/loonghao/fpt-cli/releases/download/$FptVersion/$Archive" -OutFile $Archive
+Invoke-WebRequest -Uri "https://github.com/dcc-mcp/fpt-cli/releases/download/$FptVersion/$Archive" -OutFile $Archive
 Expand-Archive -Path $Archive -DestinationPath $ExtractDir -Force
 New-Item -ItemType Directory -Force -Path $InstallDir | Out-Null
 Copy-Item -Path (Join-Path $ExtractDir "fpt.exe") -Destination (Join-Path $InstallDir "fpt.exe") -Force

--- a/workspace-hack/Cargo.toml
+++ b/workspace-hack/Cargo.toml
@@ -39,10 +39,12 @@ regex-syntax = { version = "0.8" }
 syn = { version = "2", features = ["extra-traits", "fold", "full", "visit", "visit-mut"] }
 
 [target.x86_64-unknown-linux-gnu.dependencies]
+bitflags = { version = "2", default-features = false, features = ["std"] }
 hyper = { version = "1", features = ["client", "http1", "http2", "server"] }
 hyper-util = { version = "0.1", features = ["client-legacy", "client-proxy", "server-auto"] }
 linux-raw-sys = { version = "0.12", default-features = false, features = ["auxvec", "elf", "errno", "general", "if_ether", "ioctl", "net", "netlink", "no_std", "system", "xdp"] }
 mio = { version = "1", features = ["net", "os-ext"] }
+num-traits = { version = "0.2", features = ["i128"] }
 rustix = { version = "1", features = ["event", "fs", "net", "stdio", "system", "termios"] }
 tracing = { version = "0.1", features = ["log"] }
 

--- a/workspace-hack/Cargo.toml
+++ b/workspace-hack/Cargo.toml
@@ -39,7 +39,6 @@ regex-syntax = { version = "0.8" }
 syn = { version = "2", features = ["extra-traits", "fold", "full", "visit", "visit-mut"] }
 
 [target.x86_64-unknown-linux-gnu.dependencies]
-bitflags = { version = "2", default-features = false, features = ["std"] }
 hyper = { version = "1", features = ["client", "http1", "http2", "server"] }
 hyper-util = { version = "0.1", features = ["client-legacy", "client-proxy", "server-auto"] }
 linux-raw-sys = { version = "0.12", default-features = false, features = ["auxvec", "elf", "errno", "general", "if_ether", "ioctl", "net", "netlink", "no_std", "system", "xdp"] }
@@ -69,6 +68,7 @@ tracing = { version = "0.1", features = ["log"] }
 hyper = { version = "1", features = ["client", "http1", "http2", "server"] }
 hyper-util = { version = "0.1", features = ["client-legacy", "client-proxy", "server-auto"] }
 tracing = { version = "0.1", features = ["log"] }
-windows-sys = { version = "0.61", features = ["Wdk_Foundation", "Wdk_Storage_FileSystem", "Wdk_System_IO", "Win32_Networking_WinSock", "Win32_Security_Authentication_Identity", "Win32_Security_Credentials", "Win32_Security_Cryptography", "Win32_Storage_FileSystem", "Win32_System_Console", "Win32_System_IO", "Win32_System_LibraryLoader", "Win32_System_Memory", "Win32_System_Pipes", "Win32_System_SystemInformation", "Win32_System_SystemServices", "Win32_System_Threading", "Win32_System_WindowsProgramming"] }
+windows-sys-4db8c43aad08e7ae = { package = "windows-sys", version = "0.60", features = ["Win32_Graphics_Gdi", "Win32_Security_Credentials", "Win32_Storage_FileSystem", "Win32_System_DataExchange", "Win32_System_Memory", "Win32_System_Ole", "Win32_UI_Shell"] }
+windows-sys-d4189bed749088b6 = { package = "windows-sys", version = "0.61", features = ["Wdk_Foundation", "Wdk_Storage_FileSystem", "Wdk_System_IO", "Win32_Networking_WinSock", "Win32_Security_Authentication_Identity", "Win32_Security_Credentials", "Win32_Security_Cryptography", "Win32_Storage_FileSystem", "Win32_System_Console", "Win32_System_IO", "Win32_System_LibraryLoader", "Win32_System_Memory", "Win32_System_Pipes", "Win32_System_SystemInformation", "Win32_System_SystemServices", "Win32_System_Threading", "Win32_System_WindowsProgramming"] }
 
 ### END HAKARI SECTION


### PR DESCRIPTION
## Summary
- keep release, installer, and self-update references under dcc-mcp/fpt-cli
- add auth login/logout profiles backed by the operating system credential store
- document browser-guided Autodesk/FPT user setup and profile-only agent use

## Validation
- vx just ci
- GameDemo read-only server info